### PR TITLE
Fixing the icons or import ad export buttons in the editor

### DIFF
--- a/components/Editor.js
+++ b/components/Editor.js
@@ -344,14 +344,14 @@ export default function Editor({ content }) {
             onClick={() => setIsOpenImport(true)}
             className="group rounded-lg text-xs font-semibold border flex items-center gap-1 border-zinc-200 dark:border-zinc-800 hover:border-zinc-300 dark:hover:border-zinc-700 dark:hover:text-zinc-200 hover:text-zinc-800 transition-colors duration-75 ease-out px-1.5 h-7 text-zinc-600 dark:text-zinc-400 disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            <ArrowUpTrayIcon className="size-3.5 group-data-[hover]:scale-110 transition ease-out" />
+            <ArrowDownTrayIcon className="size-3.5 group-data-[hover]:scale-110 transition ease-out" />
             Import
           </button>
           <button
             onClick={() => setIsOpenExport(true)}
             className="group rounded-lg text-xs font-semibold border flex items-center gap-1 border-zinc-200 dark:border-zinc-800 hover:border-zinc-300 dark:hover:border-zinc-700 dark:hover:text-zinc-200 hover:text-zinc-800 transition-colors duration-75 ease-out px-1.5 h-7 text-zinc-600 dark:text-zinc-400 disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            <ArrowDownTrayIcon className="size-3.5 group-data-[hover]:scale-110 transition ease-out" />
+            <ArrowUpTrayIcon className="size-3.5 group-data-[hover]:scale-110 transition ease-out" />
             Export
           </button>
         </div>

--- a/components/dialogs/export.js
+++ b/components/dialogs/export.js
@@ -10,7 +10,7 @@ import {
 } from "@/components/ui/dialog";
 import { useDialog } from "@/components/dialogs/provider";
 import {
-  ArrowDownTrayIcon,
+  ArrowUpTrayIcon,
   DocumentTextIcon,
   XMarkIcon,
 } from "@heroicons/react/16/solid";
@@ -97,7 +97,7 @@ export function ExportDialog({ editor }) {
       <DialogContent>
         <DialogHeader>
           <DialogTitle className="flex items-center gap-1.5">
-            <ArrowDownTrayIcon className="size-4" /> Export Document
+            <ArrowUpTrayIcon className="size-4" /> Export Document
           </DialogTitle>
           <DialogDescription>
             Choose the export format for your document and download it.

--- a/components/dialogs/import.js
+++ b/components/dialogs/import.js
@@ -9,7 +9,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { useDialog } from "@/components/dialogs/provider";
-import { ArrowUpTrayIcon } from "@heroicons/react/16/solid";
+import { ArrowDownTrayIcon } from "@heroicons/react/16/solid";
 import { useDropzone } from "react-dropzone";
 
 export const ImportDialog = memo(({ editor }) => {
@@ -54,7 +54,7 @@ export const ImportDialog = memo(({ editor }) => {
       <DialogContent>
         <DialogHeader>
           <DialogTitle className="flex items-center gap-1.5">
-            <ArrowUpTrayIcon className="size-4" /> Import Document
+            <ArrowDownTrayIcon className="size-4" /> Import Document
           </DialogTitle>
           <DialogDescription>
             Import your document to the editor. We support HTML, Markdown and


### PR DESCRIPTION
Fixing the swapped icons for import and export buttons in the editor